### PR TITLE
Fix file extension

### DIFF
--- a/package_MCUdude_microUPDIcore_index.json
+++ b/package_MCUdude_microUPDIcore_index.json
@@ -14,8 +14,8 @@
           "architecture": "avr",
           "version": "1.0.0",
           "category": "Contributed",
-          "url": "https://MCUdude.github.io/microUPDIcore/microUPDIcore-1.0.0.tar.gz",
-          "archiveFileName": "microUPDIcore-1.0.0.tar.gz",
+          "url": "https://MCUdude.github.io/microUPDIcore/microUPDIcore-1.0.0.tar.bz2",
+          "archiveFileName": "microUPDIcore-1.0.0.tar.bz2",
           "checksum": "SHA-256:d0079e55a786639e1352abdb919d3c4a96971893c50a4f3094df71978f392121",
           "size": "33575",
           "boards": [


### PR DESCRIPTION
This was causing BM installation to fail:
```
java.lang.RuntimeException: java.io.IOException: Input is not in the .gz format
```